### PR TITLE
optimize admm_rvv.hpp

### DIFF
--- a/include/matlib/matlib_rvv.h
+++ b/include/matlib/matlib_rvv.h
@@ -8,6 +8,8 @@
 #define __riscv_vfabs_v_f32 __riscv_vfabs_v_f32m1
 #define __riscv_vfadd_vv_f32 __riscv_vfadd_vv_f32m1
 #define __riscv_vfmacc_vv_f32 __riscv_vfmacc_vv_f32m1
+#define __riscv_vfmsac_vv_f32 __riscv_vfmsac_vv_f32m1
+#define __riscv_vfmsac_vf_f32 __riscv_vfmsac_vf_f32m1
 #define __riscv_vfmax_vv_f32 __riscv_vfmax_vv_f32m1
 #define __riscv_vfmin_vv_f32 __riscv_vfmin_vv_f32m1
 #define __riscv_vfmul_vf_f32 __riscv_vfmul_vf_f32m1
@@ -31,6 +33,8 @@
 #define __riscv_vfabs_v_f32 __riscv_vfabs_v_f32m2
 #define __riscv_vfadd_vv_f32 __riscv_vfadd_vv_f32m2
 #define __riscv_vfmacc_vv_f32 __riscv_vfmacc_vv_f32m2
+#define __riscv_vfmsac_vv_f32 __riscv_vfmsac_vv_f32m2
+#define __riscv_vfmsac_vf_f32 __riscv_vfmsac_vf_f32m2
 #define __riscv_vfmax_vv_f32 __riscv_vfmax_vv_f32m2
 #define __riscv_vfmin_vv_f32 __riscv_vfmin_vv_f32m2
 #define __riscv_vfmul_vf_f32 __riscv_vfmul_vf_f32m2
@@ -54,6 +58,8 @@
 #define __riscv_vfabs_v_f32 __riscv_vfabs_v_f32m4
 #define __riscv_vfadd_vv_f32 __riscv_vfadd_vv_f32m4
 #define __riscv_vfmacc_vv_f32 __riscv_vfmacc_vv_f32m4
+#define __riscv_vfmsac_vv_f32 __riscv_vfmsac_vv_f32m4
+#define __riscv_vfmsac_vf_f32 __riscv_vfmsac_vf_f32m4
 #define __riscv_vfmax_vv_f32 __riscv_vfmax_vv_f32m4
 #define __riscv_vfmin_vv_f32 __riscv_vfmin_vv_f32m4
 #define __riscv_vfmul_vf_f32 __riscv_vfmul_vf_f32m4
@@ -77,6 +83,8 @@
 #define __riscv_vfabs_v_f32 __riscv_vfabs_v_f32m8
 #define __riscv_vfadd_vv_f32 __riscv_vfadd_vv_f32m8
 #define __riscv_vfmacc_vv_f32 __riscv_vfmacc_vv_f32m8
+#define __riscv_vfmsac_vv_f32 __riscv_vfmsac_vv_f32m8
+#define __riscv_vfmsac_vf_f32 __riscv_vfmsac_vf_f32m8
 #define __riscv_vfmax_vv_f32 __riscv_vfmax_vv_f32m8
 #define __riscv_vfmin_vv_f32 __riscv_vfmin_vv_f32m8
 #define __riscv_vfmul_vf_f32 __riscv_vfmul_vf_f32m8

--- a/include/tinympc/admm_rvv.hpp
+++ b/include/tinympc/admm_rvv.hpp
@@ -125,25 +125,25 @@ inline void matvec_rvv_12x4(float ** a, float **b, float **c) {
 
     vec_a = __riscv_vle32_v_f32m1(ptr_a, 12);
     vec_s = __riscv_vfmul_vv_f32m1(vec_a, vec_b, 12);
-    vec_sum = __riscv_vfredosum_vs_f32m1_f32m1(vec_s, vec_zero, 12);
+    vec_sum = __riscv_vfredusum_vs_f32m1_f32m1(vec_s, vec_zero, 12);
     sum = __riscv_vfmv_f_s_f32m1_f32(vec_sum);
     ptr_c[0] = sum;
 
     vec_a = __riscv_vle32_v_f32m1(ptr_a + 12, 12);
     vec_s = __riscv_vfmul_vv_f32m1(vec_a, vec_b, 12);
-    vec_sum = __riscv_vfredosum_vs_f32m1_f32m1(vec_s, vec_zero, 12);
+    vec_sum = __riscv_vfredusum_vs_f32m1_f32m1(vec_s, vec_zero, 12);
     sum = __riscv_vfmv_f_s_f32m1_f32(vec_sum);
     ptr_c[1] = sum;
 
     vec_a = __riscv_vle32_v_f32m1(ptr_a + 24, 12);
     vec_s = __riscv_vfmul_vv_f32m1(vec_a, vec_b, 12);
-    vec_sum = __riscv_vfredosum_vs_f32m1_f32m1(vec_s, vec_zero, 12);
+    vec_sum = __riscv_vfredusum_vs_f32m1_f32m1(vec_s, vec_zero, 12);
     sum = __riscv_vfmv_f_s_f32m1_f32(vec_sum);
     ptr_c[2] = sum;
 
     vec_a = __riscv_vle32_v_f32m1(ptr_a + 36, 12);
     vec_s = __riscv_vfmul_vv_f32m1(vec_a, vec_b, 12);
-    vec_sum = __riscv_vfredosum_vs_f32m1_f32m1(vec_s, vec_zero, 12);
+    vec_sum = __riscv_vfredusum_vs_f32m1_f32m1(vec_s, vec_zero, 12);
     sum = __riscv_vfmv_f_s_f32m1_f32(vec_sum);
     ptr_c[3] = sum;
 }
@@ -165,7 +165,7 @@ inline void matvec_rvv_12x4(float ** a, float **b, float **c) {
 //     for (int i = 0; i < 4; i++) {
 //         vec_a = __riscv_vle32_v_f32m1(ptr_a + i * 12, 12); // Correctly advance ptr_a for each row
 //         vec_s = __riscv_vfmul_vv_f32m1(vec_a, vec_b, 12);
-//         vec_sum = __riscv_vfredosum_vs_f32m1_f32m1(vec_s, vec_zero, 12);
+//         vec_sum = __riscv_vfredusum_vs_f32m1_f32m1(vec_s, vec_zero, 12);
 //         sum = __riscv_vfmv_f_s_f32m1_f32(vec_sum);
 //         ptr_c[i] = sum; // Assign the result to the correct position in c
 //     }
@@ -197,10 +197,10 @@ inline void forward_pass_redu(TinySolver *solver, int i) {
     vec_s_2 = __riscv_vfmul_vv_f32m1(vec_a_2, vec_b, 12);
     vec_s_3 = __riscv_vfmul_vv_f32m1(vec_a_3, vec_b, 12);
 
-    vec_sum_0 = __riscv_vfredosum_vs_f32m1_f32m1(vec_s_0, vec_zero, 12);
-    vec_sum_1 = __riscv_vfredosum_vs_f32m1_f32m1(vec_s_1, vec_zero, 12);
-    vec_sum_2 = __riscv_vfredosum_vs_f32m1_f32m1(vec_s_2, vec_zero, 12);
-    vec_sum_3 = __riscv_vfredosum_vs_f32m1_f32m1(vec_s_3, vec_zero, 12);
+    vec_sum_0 = __riscv_vfredusum_vs_f32m1_f32m1(vec_s_0, vec_zero, 12);
+    vec_sum_1 = __riscv_vfredusum_vs_f32m1_f32m1(vec_s_1, vec_zero, 12);
+    vec_sum_2 = __riscv_vfredusum_vs_f32m1_f32m1(vec_s_2, vec_zero, 12);
+    vec_sum_3 = __riscv_vfredusum_vs_f32m1_f32m1(vec_s_3, vec_zero, 12);
 
     ptr_c[0] = __riscv_vfmv_f_s_f32m1_f32(vec_sum_0);
     ptr_c[1] = __riscv_vfmv_f_s_f32m1_f32(vec_sum_1);
@@ -387,7 +387,7 @@ inline void backward_pass_1(TinySolver *solver, int i) {
     for(int j = 0; j < NINPUTS; j++) {
         vec_q_0 = __riscv_vle32_v_f32m1(ptr_q + j * NINPUTS, NINPUTS);
         vec_s_0 = __riscv_vfmul_vv_f32m1(vec_q_0, vec_s_4, 12);
-        vec_sum_0 = __riscv_vfredosum_vs_f32m1_f32m1(vec_s_0, vec_zero, NINPUTS);
+        vec_sum_0 = __riscv_vfredusum_vs_f32m1_f32m1(vec_s_0, vec_zero, NINPUTS);
         ptr_d[j] = __riscv_vfmv_f_s_f32m1_f32(vec_sum_0);
     }
 
@@ -856,8 +856,7 @@ inline void update_linear_cost_3(TinySolver *solver) {
         vec_q = __riscv_vle32_v_f32(ptr_q, vl);
         vec_vnew = __riscv_vle32_v_f32(ptr_vnew, vl);
         vec_s = __riscv_vfsub_vv_f32(vec_vnew, vec_g, vl);
-        vec_s = __riscv_vfmul_vf_f32(vec_s, rho, vl);
-        vec_s = __riscv_vfsub_vv_f32(vec_q, vec_s, vl);
+        vec_s = __riscv_vfmsac_vf_f32(vec_q, rho, vec_s, vl);
         __riscv_vse32_v_f32(ptr_q, vec_s, vl);
     }
 


### PR DESCRIPTION
Hi, I noticed that the admm_rvv.hpp code uses ordered reductions which are slower than unordered ones on saturn.
This patch changes them to unordered reductions, and merges a `vfmul`+`vfadd` into a single `vfmsac`.

Here are measurements with the default cmake settings from the latest saturn branch with GENV256D128ShuttleConfig:
```
example_quadrotor_tracking_rvv:
original   patched
1672193    1657622 

example_quadrotor_tracking_perf_rvv:
original   patched
222        219
317        324
455        404
368        369
784        783
177        185
391        399
251        245
256        256
125        123
133        135
119        121
65         60
344        323
1539       1535
```

Overall it's slightly faster, and specifically `backward_pass_1` had the biggest improvement.
I wasn't able to run it with the higher LMUL setting, as I couldn't get that to compile, with or without the patch.